### PR TITLE
update bcrypt to 3.0.6 for compatibility with node 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "passwordless-tokenstore-test": "^0.1.1"
   },
   "dependencies": {
-    "bcrypt": "^0.8.3",
+    "bcrypt": "^3.0.6",
     "mysql": "^2.6.2",
     "passwordless-tokenstore": "0.0.10",
     "util": "^0.10.3"


### PR DESCRIPTION
Currently there's a `no member named 'ForceSet' in 'v8::Object'` error when installing password-mysql with node 10 because it's using an old version of bcrypt. This patch updates it.